### PR TITLE
LPS-110535 Fix AcceptLanguageContextProviderTest tests

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/AcceptLanguageContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/AcceptLanguageContextProviderTest.java
@@ -180,7 +180,7 @@ public class AcceptLanguageContextProviderTest {
 			Assert.assertEquals(
 				ClientErrorException.class, exception.getClass());
 			Assert.assertEquals(
-				"No available locale matches the accepted languages: es-es",
+				"No locales match the accepted languages: es-es",
 				exception.getMessage());
 		}
 	}


### PR DESCRIPTION
Maybe is too fragile to check the exception specific message and it is better to avoid this assertion...